### PR TITLE
Feature/add-release-management-tool

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -1,0 +1,33 @@
+{
+  "git": {
+    "commitMessage": "v${version}"
+  },
+  "github": {
+    "release": true,
+    "web": true
+  },
+  "npm": {
+    "publish": false
+  },
+  "plugins": {
+    "@release-it/conventional-changelog": {
+      "infile": "CHANGELOG.md",
+      "preset": {
+        "name": "angular",
+        "types": [
+          {
+            "type": "feat",
+            "section": "Features"
+          },
+          {
+            "type": "fix",
+            "section": "Bug Fixes"
+          }
+        ]
+      },
+      "context": {
+        "linkCompare": false
+      }
+    }
+  }
+}

--- a/.release-it.json
+++ b/.release-it.json
@@ -4,7 +4,8 @@
   },
   "github": {
     "release": true,
-    "web": true
+    "web": true,
+    "releaseName": "Release v${version}"
   },
   "npm": {
     "publish": false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,72 @@
+# Contributing
+
+## <a name="commit"></a> Commit Message Guidelines
+
+We have very precise rules over how our git commit messages can be formatted.  This leads to **more
+readable messages** that are easy to follow when looking through the **project history**.  But also,
+we use the git commit messages to **generate the Angular change log**.
+
+### Commit Message Format
+Each commit message consists of a **header**, a **body** and a **footer**.  The header has a special
+format that includes a **type** and a **subject**:
+
+```
+<type>: <subject>
+<BLANK LINE>
+<body>
+<BLANK LINE>
+<footer>
+```
+
+The **header** is mandatory to mention in this repository.
+
+Any line of the commit message cannot be longer than 100 characters! This allows the message to be easier
+to read on GitHub as well as in various git tools.
+
+Some samples
+```
+docs: update CONTRIBUTING.md
+fix: change input wrong emit event
+refactor: cleanup MyClass and MyService implementations
+```
+
+### Revert
+If the commit reverts a previous commit, it should begin with `revert: `, followed by the header of the reverted commit. In the body it should say: `This reverts commit <hash>.`, where the hash is the SHA of the commit being reverted.
+
+### Type
+Must be one of the following:
+
+* **build**: Changes that affect the build system or external dependencies _(example gulp, broccoli, npm)_
+* **ci**: Changes to our CI configuration files and scripts _(example: Circle, BrowserStack, SauceLabs)_
+* **docs**: Documentation only changes
+* **feat**: A new feature
+* **fix**: A bug fix
+* **perf**: A code change that improves performance
+* **refactor**: A code change that neither fixes a bug nor adds a feature
+* **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
+* **test**: Adding missing tests or correcting existing tests
+
+### Scope
+We won't append any scope to our commit in this repository.
+
+There are currently a few exceptions to the "use package name" rule:
+
+### Subject
+The subject contains a succinct description of the change:
+
+* use the imperative, present tense: "change" not "changed" nor "changes"
+* don't capitalize the first letter
+* no dot (.) at the end
+
+### Body
+Just as in the **subject**, use the imperative, present tense: "change" not "changed" nor "changes".
+The body should include the motivation for the change and contrast this with previous behavior.
+
+### Footer
+The footer should contain any information about **Breaking Changes** and is also the place to
+reference GitHub issues that this commit **Closes**.
+
+**Breaking Changes** should start with the word `BREAKING CHANGE:` with a space or two newlines.
+
+### Additional information
+https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#-commit-message-guidelines

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@storybook/react": "^6.4.18",
     "@storybook/theming": "^6.4.18",
     "@testing-library/jest-dom": "^5.11.4",
+    "@release-it/conventional-changelog": "^4.1.0",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
     "@types/jest": "^26.0.15",
@@ -53,6 +54,7 @@
     "husky": "^7.0.4",
     "lint-staged": "^12.3.3",
     "prettier": "^2.5.1",
+    "release-it": "^14.12.4",
     "web-vitals": "^1.0.1"
   },
   "scripts": {
@@ -63,6 +65,7 @@
     "eject": "react-scripts eject",
     "storybook": "start-storybook -p 6006 -s public",
     "build-storybook": "build-storybook -s public"
+    "release": "release-it"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
Nice and easy release management tool.
Added contributing file as well, i took the angular convention for it, let me know what do you think about that.
Added changelog plugin and file as well.

Run with `yarn release` and a prompt will come asking you details (patch, minor, major), set a tag for it and push it to github.

Once it's done, github page will be opened with automatically generated changelog by the commits history, you can edit as you wish then publish the release.


How it look with the automatically generated process:
![image](https://user-images.githubusercontent.com/95255488/153316648-623c4706-f339-4847-8f42-2bfe515fda27.png)
