### PR TITLE
refactor: set font weight as semibold by default on labels

### DIFF
--- a/src/common/components/AssetSelect/index.tsx
+++ b/src/common/components/AssetSelect/index.tsx
@@ -61,9 +61,7 @@ const AssetSelect = ({
         justifyContent={"space-between"}
         alignItems={"center"}
       >
-        <InputLabel fontWeight={theme.fontWeight.semibold} className={"label"}>
-          {t("common.send")}
-        </InputLabel>
+        <InputLabel className={"label"}>{t("common.send")}</InputLabel>
         <BrandSelect
           value={
             options.find((option) => option.value === selectedTokenId) || null

--- a/src/common/components/Atoms/Input/Input.tsx
+++ b/src/common/components/Atoms/Input/Input.tsx
@@ -5,7 +5,6 @@ import { IStyleableProps } from "../../../commonTypes";
 import { StyledInput } from "./styles";
 import { FlexWrapper } from "../Wrappers/Wrapper";
 import { InputLabel } from "../Label/Label";
-import { stakenetTheme as theme } from "../../../../shell/theme/stakenetTheme";
 
 type InputProps = {
   onChange?: React.ChangeEventHandler<HTMLInputElement>;
@@ -33,9 +32,7 @@ const handleInputWrapping = (
 ) => {
   return (
     <FlexWrapper alignItems={"start"}>
-      {label && (
-        <InputLabel fontWeight={theme.fontWeight.semibold}>{label}</InputLabel>
-      )}
+      {label && <InputLabel>{label}</InputLabel>}
       <Component
         type={type}
         value={value}

--- a/src/common/components/Atoms/Label/styles.ts
+++ b/src/common/components/Atoms/Label/styles.ts
@@ -12,7 +12,7 @@ export const StyledInputLabel = styled.label<StyledLabel>`
   font-size: ${theme.paragraph.md};
   color: ${(props) => (props.color ? props.color : theme.colors.white)};
   font-weight: ${(props) =>
-    props.fontWeight ? props.fontWeight : theme.fontWeight.normal};
+    props.fontWeight ? props.fontWeight : theme.fontWeight.semibold};
   margin: ${(props) =>
     props.margin ? props.margin : `0 0 ${theme.margin.md} 0`};
 

--- a/src/common/components/Molecules/BrandSelect/BrandSelect.tsx
+++ b/src/common/components/Molecules/BrandSelect/BrandSelect.tsx
@@ -8,7 +8,6 @@ import { FlexWrapper } from "../../Atoms/Wrappers/Wrapper";
 
 import { IStyleableProps } from "../../../commonTypes";
 import { colourStylesOverride, StyledSelect } from "./styles";
-import { stakenetTheme as theme } from "../../../../shell/theme/stakenetTheme";
 
 export type SelectProps = {
   value?: SelectValueType;
@@ -34,9 +33,7 @@ const BrandSelect = ({
 
   return (
     <FlexWrapper alignItems={"start"}>
-      {label && (
-        <InputLabel fontWeight={theme.fontWeight.semibold}>{label}</InputLabel>
-      )}
+      {label && <InputLabel>{label}</InputLabel>}
       <StyledSelect
         // @ts-ignore style config
         styles={colourStylesOverride}


### PR DESCRIPTION
Since all of them use font weight semibold, set it as default