### PR TITLE
Refactor/error handling

### DIFF
--- a/src/__tests__/components/RouteList.test.tsx
+++ b/src/__tests__/components/RouteList.test.tsx
@@ -36,7 +36,7 @@ describe("The Bridge route list", () => {
     const routeWithoutError = container.querySelector<HTMLDivElement>(
       `#route-${props.routes[0].id}`
     );
-    const routeWithError = screen.getByText(/error-showing-route/);
+    const routeWithError = screen.getByText(/errors.showing-route/);
 
     expect(asFragment()).toMatchSnapshot();
     expect(container.childElementCount).toBe(props.routes.length);
@@ -60,7 +60,7 @@ describe("The Bridge route list", () => {
     };
     const { container, asFragment } = render(<RouteList {...props} />);
 
-    const routesWithError = screen.getAllByText(/error-showing-route/);
+    const routesWithError = screen.getAllByText(/errors.showing-route/);
 
     expect(asFragment()).toMatchSnapshot();
     expect(container.childElementCount).toBe(props.routes.length);

--- a/src/__tests__/components/__snapshots__/RouteList.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/RouteList.test.tsx.snap
@@ -132,7 +132,7 @@ exports[`The Bridge route list should render the routes, when a error occurs 1`]
     <p
       style="font-size: 1.6rem; color: rgb(191, 44, 68); margin: auto; text-align: center;"
     >
-      error-showing-routes
+      errors.showing-routes
     </p>
   </div>
 </DocumentFragment>
@@ -147,7 +147,7 @@ exports[`The Bridge route list should render the routes, when all of them have e
     <p
       style="font-size: 1.6rem; color: rgb(191, 44, 68); margin: auto; text-align: center;"
     >
-      error-showing-routes
+      errors.showing-routes
     </p>
   </div>
   <div
@@ -157,7 +157,7 @@ exports[`The Bridge route list should render the routes, when all of them have e
     <p
       style="font-size: 1.6rem; color: rgb(191, 44, 68); margin: auto; text-align: center;"
     >
-      error-showing-routes
+      errors.showing-routes
     </p>
   </div>
 </DocumentFragment>

--- a/src/api/allowancesService.ts
+++ b/src/api/allowancesService.ts
@@ -1,19 +1,9 @@
 import {
   BuildAllowanceRequestDto,
   BuildAllowanceResponseDto,
-  CheckAllowanceRequestDto,
-  CheckAllowanceResponseDto,
 } from "../common/dtos";
-import { getBuildApprovalTxUrl, getCheckAllowanceUrl } from "./apiRoutes";
+import { getBuildApprovalTxUrl } from "./apiRoutes";
 import { fetchWrapper } from "../helpers/fetchWrapper";
-
-// TODO NOT USED ?
-export const checkAllowance = async (
-  dto: CheckAllowanceRequestDto
-): Promise<CheckAllowanceResponseDto> => {
-  const response = await fetchWrapper.get(getCheckAllowanceUrl(dto));
-  return await response.json();
-};
 
 export const buildApprovalTx = async (
   dto: BuildAllowanceRequestDto

--- a/src/api/allowancesService.ts
+++ b/src/api/allowancesService.ts
@@ -4,28 +4,20 @@ import {
   CheckAllowanceRequestDto,
   CheckAllowanceResponseDto,
 } from "../common/dtos";
-import { fetchWrapper } from "../helpers/fetchWrapper";
 import { getBuildApprovalTxUrl, getCheckAllowanceUrl } from "./apiRoutes";
-import { handleResponse } from "../helpers/responseHandler";
+import { fetchWrapper } from "../helpers/fetchWrapper";
 
+// TODO NOT USED ?
 export const checkAllowance = async (
   dto: CheckAllowanceRequestDto
-): Promise<CheckAllowanceResponseDto | undefined> => {
-  try {
-    const response = await fetchWrapper.get(getCheckAllowanceUrl(dto));
-    return await handleResponse(response);
-  } catch (e) {
-    console.log("Error check allowance", e);
-  }
+): Promise<CheckAllowanceResponseDto> => {
+  const response = await fetchWrapper.get(getCheckAllowanceUrl(dto));
+  return await response.json();
 };
 
 export const buildApprovalTx = async (
   dto: BuildAllowanceRequestDto
-): Promise<BuildAllowanceResponseDto | undefined> => {
-  try {
-    const response = await fetchWrapper.get(getBuildApprovalTxUrl(dto));
-    return handleResponse(response);
-  } catch (e) {
-    console.log("Error building approval transaction", e);
-  }
+): Promise<BuildAllowanceResponseDto> => {
+  const response = await fetchWrapper.get(getBuildApprovalTxUrl(dto));
+  return await response.json();
 };

--- a/src/api/apiRoutes.ts
+++ b/src/api/apiRoutes.ts
@@ -1,14 +1,10 @@
 import {
   BuildAllowanceRequestDto,
   BuildTxRequestDto,
-  CheckAllowanceRequestDto,
   QuoteRequestDto,
 } from "../common/dtos";
 
 const { REACT_APP_API_URL } = process.env;
-
-export const getCheckAllowanceUrl = (dto: CheckAllowanceRequestDto) =>
-  `${REACT_APP_API_URL}/approval/check-allowance?chainId=${dto.chainId}&owner=${dto.owner}&tokenAddress=${dto.tokenAddress}`;
 
 export const getBuildApprovalTxUrl = (dto: BuildAllowanceRequestDto) =>
   `${REACT_APP_API_URL}/approval/build-tx?chainId=${dto.chainId}&owner=${dto.owner}&tokenAddress=${dto.tokenAddress}&amount=${dto.amount}`;

--- a/src/api/apiRoutes.ts
+++ b/src/api/apiRoutes.ts
@@ -14,7 +14,7 @@ export const getBuildApprovalTxUrl = (dto: BuildAllowanceRequestDto) =>
   `${REACT_APP_API_URL}/approval/build-tx?chainId=${dto.chainId}&owner=${dto.owner}&tokenAddress=${dto.tokenAddress}&amount=${dto.amount}`;
 
 export const getUserBalancesUrl = (address: string, chainId: number) =>
-  `${REACT_APP_API_URL}/balances?address=${address}&&chainId=${chainId}`;
+  `${REACT_APP_API_URL}/balances?address=${address}&chainId=${chainId}`;
 
 export const getBuildTxRequestUrl = (dto: BuildTxRequestDto) =>
   `${REACT_APP_API_URL}/bridge/build-tx?recipient=${dto.recipient}&fromAsset=${dto.fromAsset}&fromChainId=${dto.fromChainId}&toAsset=${dto.toAsset}&toChainId=${dto.toChainId}&amount=${dto.amount}&routeId=${dto.routeId}`;

--- a/src/api/balancesService.ts
+++ b/src/api/balancesService.ts
@@ -1,18 +1,16 @@
 import { TokenBalanceDto } from "../common/dtos";
 import { fetchWrapper } from "../helpers/fetchWrapper";
 import { getUserBalancesUrl } from "./apiRoutes";
-import { handleResponse } from "../helpers/responseHandler";
 
+/**
+ * API call to retrieve the user balance on a particular chain
+ * @param address
+ * @param chainId
+ */
 export const getUserAddressBalances = async (
   address: string,
   chainId: number
-): Promise<TokenBalanceDto[] | undefined> => {
-  try {
-    const response = await fetchWrapper.get(
-      getUserBalancesUrl(address, chainId)
-    );
-    return await handleResponse(response);
-  } catch (e) {
-    console.log("Error getting user balance", e);
-  }
+): Promise<TokenBalanceDto[]> => {
+  const response = await fetchWrapper.get(getUserBalancesUrl(address, chainId));
+  return await response.json();
 };

--- a/src/api/bridgeService.ts
+++ b/src/api/bridgeService.ts
@@ -6,26 +6,25 @@ import {
 } from "../common/dtos";
 import { fetchWrapper } from "../helpers/fetchWrapper";
 import { getBuildTxRequestUrl, getQuoteUrl } from "./apiRoutes";
-import { handleResponse } from "../helpers/responseHandler";
 
+/**
+ * API call to build the transaction request
+ * @param dto
+ */
 export const buildBridgeTx = async (
   dto: BuildTxRequestDto
-): Promise<BuildTxResponseDto | undefined> => {
-  try {
-    const response = await fetchWrapper.get(getBuildTxRequestUrl(dto));
-    return await handleResponse(response);
-  } catch (e) {
-    console.log("Error building bridge tx", e);
-  }
+): Promise<BuildTxResponseDto> => {
+  const response = await fetchWrapper.get(getBuildTxRequestUrl(dto));
+  return await response.json();
 };
 
+/**
+ * API call to get a quote with the values provided from the user for bridging
+ * @param dto
+ */
 export const getQuote = async (
   dto: QuoteRequestDto
-): Promise<QuoteResponseDto | undefined> => {
-  try {
-    const response = await fetchWrapper.get(getQuoteUrl(dto));
-    return await handleResponse(response);
-  } catch (e) {
-    console.log("Error getting quote", e);
-  }
+): Promise<QuoteResponseDto> => {
+  const response = await fetchWrapper.get(getQuoteUrl(dto));
+  return await response.json();
 };

--- a/src/api/commonService.ts
+++ b/src/api/commonService.ts
@@ -1,26 +1,22 @@
 import { ChainResponseDto, TokenResponseDto } from "../common/dtos";
 import { fetchWrapper } from "../helpers/fetchWrapper";
 import { getAllChainsUrl, getBridgeTokensUrl } from "./apiRoutes";
-import { handleResponse } from "../helpers/responseHandler";
 
+/**
+ * Fetch all tokens available on the chain
+ * @param chainId
+ */
 export const getBridgeTokens = async (
   chainId: number
-): Promise<TokenResponseDto[] | undefined> => {
-  try {
-    const response = await fetchWrapper.get(getBridgeTokensUrl(chainId));
-    return await handleResponse(response);
-  } catch (e) {
-    console.log("Error getting bridge tokens", e);
-  }
+): Promise<TokenResponseDto[]> => {
+  const response = await fetchWrapper.get(getBridgeTokensUrl(chainId));
+  return await response.json();
 };
 
-export const getAllChains = async (): Promise<
-  ChainResponseDto[] | undefined
-> => {
-  try {
-    const response = await fetchWrapper.get(getAllChainsUrl());
-    return await handleResponse(response);
-  } catch (e) {
-    console.log("Error getting chains", e);
-  }
+/**
+ * Fetch all chains available for bridging
+ */
+export const getAllChains = async (): Promise<ChainResponseDto[]> => {
+  const response = await fetchWrapper.get(getAllChainsUrl());
+  return await response.json();
 };

--- a/src/common/components/ConnectWallet/ConnectWallet.tsx
+++ b/src/common/components/ConnectWallet/ConnectWallet.tsx
@@ -30,14 +30,14 @@ const ConnectWallet = () => {
 
     navigator.clipboard.writeText(address).then(
       () => {
-        toast.info(t("notification.copied"), {
+        toast.info(t("common.copied"), {
           ...DEFAULT_NOTIFY_CONFIG,
           autoClose: 1000,
           pauseOnHover: false,
         });
       },
       (err) => {
-        toast.error(`${t("notification.error-copy")} ${address} `, {
+        toast.error(`${t("errors.copy")} ${address} `, {
           ...DEFAULT_NOTIFY_CONFIG,
           autoClose: false,
         });

--- a/src/common/components/Molecules/BridgeRoutes/RouteList.tsx
+++ b/src/common/components/Molecules/BridgeRoutes/RouteList.tsx
@@ -81,7 +81,7 @@ const RouteList = ({
                 textAlign: "center",
               }}
             >
-              {t("error-showing-routes")}
+              {t("errors.showing-routes")}
             </p>
           </RouteItemContainerCard>
         );

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -28,3 +28,10 @@ export const DEFAULT_NOTIFY_CONFIG: NotificationType = {
   closeOnClick: false,
   hideProgressBar: true,
 };
+export const ERROR_NOTIFY_CONFIG: NotificationType = {
+  position: "bottom-right",
+  autoClose: false,
+  closeOnClick: true,
+  hideProgressBar: true,
+  pauseOnHover: false,
+};

--- a/src/common/dtos.ts
+++ b/src/common/dtos.ts
@@ -1,14 +1,3 @@
-export interface CheckAllowanceRequestDto {
-  chainId: string;
-  owner: string;
-  tokenAddress: string;
-}
-
-export interface CheckAllowanceResponseDto {
-  value: string;
-  tokenAddress: string;
-}
-
 export interface BuildAllowanceRequestDto {
   chainId: number;
   owner: string;

--- a/src/common/hooks/useChains.ts
+++ b/src/common/hooks/useChains.ts
@@ -4,7 +4,8 @@ import { useTranslation } from "react-i18next";
 import { getAllChains } from "../../api/commonService";
 import { ChainResponseDto } from "../dtos";
 import { SupportedChainId } from "../enums";
-import { handleError } from "../../helpers/error";
+import { handleFetchError } from "../../helpers/error";
+
 const { REACT_APP_DEFAULT_NETWORK_ID } = process.env;
 
 function useChains() {
@@ -24,7 +25,7 @@ function useChains() {
           setChains(filtered);
         }
       } catch (err) {
-        handleError(t("error-getting-chains"), err);
+        handleFetchError(t("errors.getting-chains"), err);
       }
     }
     getChains();

--- a/src/common/hooks/useChains.ts
+++ b/src/common/hooks/useChains.ts
@@ -1,10 +1,14 @@
 import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+
 import { getAllChains } from "../../api/commonService";
 import { ChainResponseDto } from "../dtos";
 import { SupportedChainId } from "../enums";
+import { handleError } from "../../helpers/error";
 const { REACT_APP_DEFAULT_NETWORK_ID } = process.env;
 
 function useChains() {
+  const { t } = useTranslation();
   const [chains, setChains] = useState<ChainResponseDto[]>([]);
 
   useEffect(() => {
@@ -19,8 +23,8 @@ function useChains() {
           filtered = result.filter((chain) => chain.isTestnet === isTestnet);
           setChains(filtered);
         }
-      } catch (e) {
-        console.log("Get chains failed:", e);
+      } catch (err) {
+        handleError(t("error-getting-chains"), err);
       }
     }
     getChains();

--- a/src/common/hooks/useTokens.ts
+++ b/src/common/hooks/useTokens.ts
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next";
 import { getBridgeTokens } from "../../api/commonService";
 import { ChainResponseDto, TokenResponseDto } from "../dtos";
 import { ETH } from "../constants";
-import { handleError } from "../../helpers/error";
+import { handleFetchError } from "../../helpers/error";
 
 function useTokens(
   chainFrom: ChainResponseDto,
@@ -28,7 +28,7 @@ function useTokens(
           setTokens(result);
         }
       } catch (err) {
-        handleError(t("error-getting-bridge-tokens"), err);
+        handleFetchError(t("errors.getting-bridge-tokens"), err);
       }
     }
     if (network) {

--- a/src/common/hooks/useTokens.ts
+++ b/src/common/hooks/useTokens.ts
@@ -1,7 +1,10 @@
 import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+
 import { getBridgeTokens } from "../../api/commonService";
 import { ChainResponseDto, TokenResponseDto } from "../dtos";
 import { ETH } from "../constants";
+import { handleError } from "../../helpers/error";
 
 function useTokens(
   chainFrom: ChainResponseDto,
@@ -9,6 +12,7 @@ function useTokens(
   asset: number
 ) {
   const [tokens, setTokens] = useState<TokenResponseDto[]>([]);
+  const { t } = useTranslation();
 
   const token = tokens.find((t) => t.id === asset);
   const isEth = token?.symbol.toString().toLowerCase() === ETH;
@@ -23,8 +27,8 @@ function useTokens(
         if (result && result.length > 0) {
           setTokens(result);
         }
-      } catch (e) {
-        console.log("Get tokens error", e);
+      } catch (err) {
+        handleError(t("error-getting-bridge-tokens"), err);
       }
     }
     if (network) {

--- a/src/helpers/error.ts
+++ b/src/helpers/error.ts
@@ -3,12 +3,12 @@ import { ERROR_NOTIFY_CONFIG } from "../common/constants";
 
 /**
  * Handler for errors
- * Notify the user via the UI which error occured
+ * Notify the user via the UI which error occurred
  * Log the error to the remote (TODO)
  * @param userErrorMessage
  * @param error
  */
-export const handleError = (userErrorMessage: string, error: any) => {
+export const handleFetchError = (userErrorMessage: string, error: any) => {
   toast.error(userErrorMessage, {
     ...ERROR_NOTIFY_CONFIG,
   });

--- a/src/helpers/error.ts
+++ b/src/helpers/error.ts
@@ -1,0 +1,16 @@
+import { toast } from "react-toastify";
+import { ERROR_NOTIFY_CONFIG } from "../common/constants";
+
+/**
+ * Handler for errors
+ * Notify the user via the UI which error occured
+ * Log the error to the remote (TODO)
+ * @param userErrorMessage
+ * @param error
+ */
+export const handleError = (userErrorMessage: string, error: any) => {
+  toast.error(userErrorMessage, {
+    ...ERROR_NOTIFY_CONFIG,
+  });
+  console.error(error);
+};

--- a/src/helpers/requestHelper.ts
+++ b/src/helpers/requestHelper.ts
@@ -1,8 +1,0 @@
-export const parseJson = (jsonString: string) => {
-  try {
-    return JSON.parse(jsonString);
-  } catch (error) {
-    console.log("Error parsing JSON", error);
-    return jsonString;
-  }
-};

--- a/src/helpers/responseHandler.ts
+++ b/src/helpers/responseHandler.ts
@@ -1,9 +1,0 @@
-import { parseJson } from "./requestHelper";
-
-export async function handleResponse<T>(response: Response): Promise<T> {
-  const text = await response.text();
-  if (!response.ok) {
-    throw Error(response.statusText + " " + text);
-  }
-  return text && parseJson(text);
-}

--- a/src/i18n/locales/en/translations.json
+++ b/src/i18n/locales/en/translations.json
@@ -20,9 +20,16 @@
   },
   "notification": {
     "copied": "Copied!",
-    "error-copy": "Couldn't copy the address",
     "not-enough-funds": "Not enough funds",
-    "error-bridging-funds": "Error bridging funds",
-    "error-approving-wallet": "Error approving wallet"
+    "error-copy": "Failed to copy your address",
+    "error-bridging-funds": "Failed bridging funds",
+    "error-approving-wallet": "Failed trying approving your wallet",
+    "error-checking-allowance": "Failed to check your allowance",
+    "error-checking-wallet-balance": "Failed to get wallet balance",
+    "error-getting-quote": "Failed to get quote",
+    "error-getting-bridge-tokens": "Failed to get bridge tokens",
+    "error-getting-chains": "Failed to get chains",
+    "error-building-bridge-tx": "Failed to build bridge tx",
+    "error-building-approval-transaction": "Failed building the approval transaction"
   }
 }

--- a/src/i18n/locales/en/translations.json
+++ b/src/i18n/locales/en/translations.json
@@ -16,20 +16,20 @@
     "receive": "Receive",
     "loading": "Loading",
     "approve": "Approve",
+    "copied": "Copied!",
     "no-options-in-select": "No options"
   },
-  "notification": {
-    "copied": "Copied!",
-    "not-enough-funds": "Not enough funds",
-    "error-copy": "Failed to copy your address",
-    "error-bridging-funds": "Failed bridging funds",
-    "error-approving-wallet": "Failed trying approving your wallet",
-    "error-checking-allowance": "Failed to check your allowance",
-    "error-checking-wallet-balance": "Failed to get wallet balance",
-    "error-getting-quote": "Failed to get quote",
-    "error-getting-bridge-tokens": "Failed to get bridge tokens",
-    "error-getting-chains": "Failed to get chains",
-    "error-building-bridge-tx": "Failed to build bridge tx",
-    "error-building-approval-transaction": "Failed building the approval transaction"
+  "not-enough-funds": "Not enough funds",
+  "errors": {
+    "copy": "Failed to copy your address",
+    "bridging-funds": "Failed to bridge funds",
+    "approving-wallet": "Failed trying approving your wallet",
+    "checking-allowance": "Failed to check your allowance",
+    "checking-wallet-balance": "Failed to get wallet balance",
+    "getting-quote": "Failed to get quote",
+    "getting-bridge-tokens": "Failed to get bridge tokens",
+    "getting-chains": "Failed to get chains",
+    "building-bridge-tx": "Failed to build the bridge transaction",
+    "building-approval-transaction": "Failed to build the approval transaction"
   }
 }

--- a/src/modules/Home/Home.tsx
+++ b/src/modules/Home/Home.tsx
@@ -205,7 +205,7 @@ const Home = ({ chains }: Props) => {
         });
       }
       if (isNotEnoughBalance) {
-        toast.error(t("notification.not-enough-funds"), {
+        toast.error(t("not-enough-funds"), {
           ...DEFAULT_NOTIFY_CONFIG,
           autoClose: false,
         });

--- a/src/modules/Home/useHome.ts
+++ b/src/modules/Home/useHome.ts
@@ -20,6 +20,7 @@ import {
   ETH,
   HOP_BRIDGE_GOERLI,
 } from "../../common/constants";
+import { handleError } from "../../helpers/error";
 const { REACT_APP_DEFAULT_NETWORK_ID } = process.env;
 
 export default function useHome() {
@@ -114,8 +115,8 @@ export default function useHome() {
             setIsDisabled(false);
           }
         }
-      } catch (e) {
-        console.error("Get quote error", e);
+      } catch (err) {
+        handleError(t("error-getting-quote"), err);
       } finally {
         setInProgress(false);
       }
@@ -155,8 +156,8 @@ export default function useHome() {
           setBuildApproveTx(response);
         }
       }
-    } catch (e) {
-      console.error("Build approve data error", e);
+    } catch (err) {
+      handleError(t("error-building-approval-transaction"), err);
     }
   };
 
@@ -196,11 +197,8 @@ export default function useHome() {
           }
         }
       }
-    } catch (e: any) {
-      console.error("On approve wallet error", e);
-      toast.error(t("notification.error-approving-wallet"), {
-        autoClose: false,
-      });
+    } catch (err) {
+      handleError(t("notification.error-approving-wallet"), err);
     } finally {
       setInProgress(false);
     }
@@ -213,8 +211,8 @@ export default function useHome() {
         if (response) {
           setBridgeTx(response);
         }
-      } catch (e) {
-        console.error("Build bridge tx error", e);
+      } catch (err) {
+        handleError(t("error-building-bridge-tx"), err);
       }
     }
   };

--- a/src/modules/Home/useHome.ts
+++ b/src/modules/Home/useHome.ts
@@ -1,5 +1,4 @@
 import _ from "lodash";
-import { toast } from "react-toastify";
 import { TransactionRequest } from "@ethersproject/abstract-provider";
 import { useWeb3 } from "@chainsafe/web3-context";
 import { useCallback, useEffect, useState } from "react";
@@ -15,12 +14,9 @@ import {
   QuoteRequestDto,
   RouteDto,
 } from "../../common/dtos";
-import {
-  DEFAULT_NOTIFY_CONFIG,
-  ETH,
-  HOP_BRIDGE_GOERLI,
-} from "../../common/constants";
-import { handleError } from "../../helpers/error";
+import { ETH, HOP_BRIDGE_GOERLI } from "../../common/constants";
+import { handleFetchError } from "../../helpers/error";
+
 const { REACT_APP_DEFAULT_NETWORK_ID } = process.env;
 
 export default function useHome() {
@@ -116,7 +112,7 @@ export default function useHome() {
           }
         }
       } catch (err) {
-        handleError(t("error-getting-quote"), err);
+        handleFetchError(t("errors.getting-quote"), err);
       } finally {
         setInProgress(false);
       }
@@ -127,7 +123,7 @@ export default function useHome() {
     await onGetQuote(dto);
   };
 
-  const onDebouncedQuote = useCallback(_.debounce(onQuote, 3000), []);
+  const onDebouncedQuote = useCallback(_.debounce(onQuote, 0), []);
 
   const onBuildApproveTxData = async (
     owner: string,
@@ -157,7 +153,7 @@ export default function useHome() {
         }
       }
     } catch (err) {
-      handleError(t("error-building-approval-transaction"), err);
+      handleFetchError(t("errors.building-approval-transaction"), err);
     }
   };
 
@@ -198,7 +194,7 @@ export default function useHome() {
         }
       }
     } catch (err) {
-      handleError(t("notification.error-approving-wallet"), err);
+      handleFetchError(t("errors.approving-wallet"), err);
     } finally {
       setInProgress(false);
     }
@@ -212,7 +208,7 @@ export default function useHome() {
           setBridgeTx(response);
         }
       } catch (err) {
-        handleError(t("error-building-bridge-tx"), err);
+        handleFetchError(t("errors.building-bridge-tx"), err);
       }
     }
   };
@@ -243,12 +239,8 @@ export default function useHome() {
         if (receipt.logs) {
           console.info("Move receipt logs", receipt.logs);
         }
-      } catch (e: any) {
-        console.error("Bridge funds error", e);
-        toast.error(t("notification.error-bridging-funds"), {
-          ...DEFAULT_NOTIFY_CONFIG,
-          autoClose: false,
-        });
+      } catch (err) {
+        handleFetchError(t("errors.bridging-funds"), err);
       }
     }
   };

--- a/src/modules/Home/useWalletBalances.ts
+++ b/src/modules/Home/useWalletBalances.ts
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 
 import { getUserAddressBalances } from "../../api/balancesService";
 import { TokenBalanceDto } from "../../common/dtos";
-import { handleError } from "../../helpers/error";
+import { handleFetchError } from "../../helpers/error";
 
 const { REACT_APP_DEFAULT_NETWORK_ID } = process.env;
 
@@ -24,7 +24,7 @@ function useWalletBalances(address: string, chainId: number) {
           }
         }
       } catch (err) {
-        handleError(t("error-checking-wallet-balance"), err);
+        handleFetchError(t("errors.checking-wallet-balance"), err);
       }
     }
     getWalletBalances();

--- a/src/modules/Home/useWalletBalances.ts
+++ b/src/modules/Home/useWalletBalances.ts
@@ -1,10 +1,15 @@
 import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+
 import { getUserAddressBalances } from "../../api/balancesService";
 import { TokenBalanceDto } from "../../common/dtos";
+import { handleError } from "../../helpers/error";
+
 const { REACT_APP_DEFAULT_NETWORK_ID } = process.env;
 
 function useWalletBalances(address: string, chainId: number) {
   const [walletBalances, setWalletBalances] = useState<TokenBalanceDto[]>([]);
+  const { t } = useTranslation();
 
   useEffect(() => {
     async function getWalletBalances() {
@@ -18,8 +23,8 @@ function useWalletBalances(address: string, chainId: number) {
             setWalletBalances(result);
           }
         }
-      } catch (e) {
-        console.log("Wallet balances error", e);
+      } catch (err) {
+        handleError(t("error-checking-wallet-balance"), err);
       }
     }
     getWalletBalances();


### PR DESCRIPTION
delete handleResponse() method
simplify fetch calls by returning directly the result of the json()

doing so we ensure the error aren't swallowed and we can give custom error messages on the caller itself. It is also a good move when we will implement external logging

remove checkAllowance method/endpoint/dtos since they are not used anywhere (let me know if im missing something and need to rollback for these)